### PR TITLE
Better searching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 npm-debug.log
+build/js

--- a/example/example.js
+++ b/example/example.js
@@ -10,7 +10,7 @@ ArsArsenal.render(app, {
   },
 
   onChange(value) {
-    console.log(value);
+    console.log("Value changed to %s", value);
   }
 
 });

--- a/example/example.js
+++ b/example/example.js
@@ -1,11 +1,15 @@
-var React      = require('react/addons');
-var ArsArsenal = require('../src/index');
+let React      = require('react/addons');
+let ArsArsenal = require('../src/index');
 
 ArsArsenal.render(app, {
 
-  url: 'photos.json',
+  url: 'http://localhost:7000/photos',
 
-  onChange: function(value) {
+  onError(response) {
+    return `${ response.code }: ${ response.message }`;
+  },
+
+  onChange(value) {
     console.log(value);
   }
 

--- a/example/server.js
+++ b/example/server.js
@@ -30,9 +30,9 @@ server.get('/photos/:id', function(req, res) {
 
   var payload = photos.filter(function(photo) {
     return pattern.test(photo.id);
-  });
+  })[0];
 
-  res.send(payload);
+  payload? res.send(payload) : res.error(404);
 });
 
 server.listen(7000, function() {

--- a/example/server.js
+++ b/example/server.js
@@ -1,0 +1,40 @@
+var restify = require('restify');
+var photos  = require('./photos');
+var server  = restify.createServer();
+
+server.use(restify.queryParser());
+server.use(restify.CORS());
+
+server.use(function(req, res, next) {
+  console.log("%s: %s ? %s", req.route.method, req.route.path, JSON.stringify(req.params));
+  next();
+});
+
+server.get('/photos', function(req, res) {
+  var payload = photos;
+  var query   = req.query.q;
+
+  if (query) {
+    var pattern = new RegExp('^' + escape(query), 'i');
+
+    payload = photos.filter(function(photo) {
+      return pattern.test(photo.caption);
+    });
+  }
+
+  res.send(payload)
+});
+
+server.get('/photos/:id', function(req, res) {
+  var pattern = new RegExp('^' + escape(req.params.id) + '$', 'i');
+
+  var payload = photos.filter(function(photo) {
+    return pattern.test(photo.id);
+  });
+
+  res.send(payload);
+});
+
+server.listen(7000, function() {
+  console.log('%s listening at %s', server.name, server.url);
+});

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "json-loader": "^0.5.1",
     "jsx-loader": "^0.12.2",
     "react-tools": "^0.12.1",
+    "restify": "^2.8.4",
     "sass-loader": "^0.3.1",
     "style-loader": "^0.8.2",
     "webpack": "^1.4.13",

--- a/src/components/__tests__/search-test.js
+++ b/src/components/__tests__/search-test.js
@@ -16,7 +16,7 @@ describe('Search', function() {
     // remember the change callback is debounced
     setTimeout(function() {
       expect(callback).lastCalledWith('')
-    }, 100)
+    }, Search.INTERVAL)
   })
 
   it ('triggers the full term above 2 characters', function() {
@@ -31,7 +31,7 @@ describe('Search', function() {
     // remember the change callback is debounced
     setTimeout(function() {
       expect(callback).lastCalledWith('Large Enough')
-    }, 100)
+    }, Search.INTERVAL)
   })
 
 })

--- a/src/components/ars.js
+++ b/src/components/ars.js
@@ -3,17 +3,14 @@
  * The main element for Ars Arsenal
  */
 
-import Photo     from "../stores/photo"
-import Picker    from "./picker"
-import React     from "react"
-import Selection from "./selection"
-import Sync      from '../mixins/sync'
+import Photo      from "../stores/photo"
+import Picker     from "./picker"
+import React      from "react"
+import Selection  from "./selection"
 
 let Types = React.PropTypes
 
 let Ars = React.createClass({
-
-  mixins: [ Sync ],
 
   propTypes: {
     url      : Types.string.isRequired,
@@ -35,27 +32,24 @@ let Ars = React.createClass({
   },
 
   getPicker() {
-    let { error, items, search, picked } = this.state
+    let { search, picked } = this.state
+    let { url } = this.props
 
     return (
-      <Picker error={ error }
-              items={ items }
-              key="dialog"
-              onSearch={ this._onSearchChange }
+      <Picker key="dialog"
               onChange={ this._onGalleryPicked }
               onExit={ this._onExit }
-              picked={ picked } />
+              picked={ picked }
+              url={ url } />
     )
   },
 
   render() {
-    let { dialogOpen, items, picked, search } = this.state
-
-    let record = Photo.find(items, picked)
+    let { dialogOpen, picked, search } = this.state
 
     return (
       <div className="ars">
-        <Selection onClick={ this._onOpenClick } photo={ record }/>
+        <Selection onClick={ this._onOpenClick } slug={ picked } url={ this.props.url } />
         { dialogOpen && this.getPicker() }
       </div>
     )
@@ -63,10 +57,6 @@ let Ars = React.createClass({
 
   _onOpenClick() {
     this.setState({ dialogOpen: true, search: null })
-  },
-
-  _onSearchChange(search) {
-    this.setState({ search }, this.fetch)
   },
 
   _onGalleryPicked(picked) {

--- a/src/components/picker.js
+++ b/src/components/picker.js
@@ -3,20 +3,22 @@
  * The a modal that appears to select a gallery image
  */
 
-import Button  from './ui/button'
-import Dialog  from './ui/dialog'
-import Gallery from './gallery'
-import React   from 'react'
-import Search  from './search'
+import Button     from './ui/button'
+import Collection from '../mixins/collection'
+import Dialog     from './ui/dialog'
+import Gallery    from './gallery'
+import React      from 'react'
+import Search     from './search'
 
 let Types = React.PropTypes
 
 let Picker = React.createClass({
 
+  mixins: [ Collection ],
+
   propTypes: {
     onChange : Types.func.isRequired,
-    onExit   : Types.func.isRequired,
-    onSearch : Types.func.isRequired
+    onExit   : Types.func.isRequired
   },
 
   getDefaultProps() {
@@ -50,14 +52,15 @@ let Picker = React.createClass({
   },
 
   render() {
-    let { error, items, onSearch, onChange, search } = this.props
+    let { onChange } = this.props
+    let { error, items, search } = this.state
 
     return (
       <Dialog onExit={ this.props.onExit }>
 
         <header className="ars-dialog-header">
           <h1 className="ars-dialog-title">Please select a photo</h1>
-          <Search key="search" onChange={ onSearch } />
+          <Search key="search" onChange={ this._onSearchChange } />
         </header>
 
         { this.getError() }
@@ -71,6 +74,10 @@ let Picker = React.createClass({
 
       </Dialog>
     )
+  },
+
+  _onSearchChange(search) {
+    this.setState({ search }, this.fetch)
   },
 
   _onPicked(picked) {

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -9,15 +9,16 @@ import UniqueID from '../mixins/uniqueId'
 
 let Types = React.PropTypes
 
-// The minimum number of characters before searching
-const THRESHOLD = 2
-
-// The minimum time between change events
-const INTERVAL  = 50
-
 let Search = React.createClass({
 
   mixins: [ UniqueID ],
+
+  statics: {
+    // The minimum number of characters before searching
+    THRESHOLD: 2,
+    // The minimum time between change events
+    INTERVAL: 150
+  },
 
   propTypes: {
     onChange : Types.func.isRequired
@@ -25,7 +26,7 @@ let Search = React.createClass({
 
   getInitialState() {
     return {
-      debouncedChange: debounce(this.props.onChange, INTERVAL)
+      debouncedChange: debounce(this.props.onChange, Search.INTERVAL)
     }
   },
 
@@ -43,7 +44,7 @@ let Search = React.createClass({
 
   _onChange(e) {
     let query  = this.refs.input.getDOMNode().value || ''
-    let result = query.length >= THRESHOLD ? query : ''
+    let result = query.length >= Search.THRESHOLD ? query : ''
 
     this.state.debouncedChange(result)
   },

--- a/src/components/selection.js
+++ b/src/components/selection.js
@@ -1,18 +1,22 @@
 /**
  * Selection
  */
-
-import Button from "./ui/button";
-import Image from "./ui/image";
-import React from "react";
-
-const SHOULD_SELECT = 'Select an image'
-const PICK_ANOTHER  = 'Choose another image'
+import Button from "./ui/button"
+import Image  from "./ui/image"
+import React  from "react"
+import Record from "../mixins/record"
 
 let Selection = React.createClass({
 
+  mixins: [ Record ],
+
+  statics: {
+    PICK_ANOTHER  : "Choose another image",
+    SHOULD_SELECT : "Select an image"
+  },
+
   getPhoto() {
-    let { caption, url } = this.props.photo
+    let { caption, url } = this.state.item
 
     return (
       <Image className="ars-selection-photo" alt={ caption } src={ url } />
@@ -20,14 +24,14 @@ let Selection = React.createClass({
   },
 
   render() {
-    let hasPhoto = this.props.photo
+    let hasPhoto = !!this.state.item
 
     return (
       <Button className="ars-selection" onClick={ this._onClick }>
         { hasPhoto && this.getPhoto() }
 
         <span className="ars-selection-caption">
-          { hasPhoto ? PICK_ANOTHER : SHOULD_SELECT }
+          { hasPhoto ? Selection.PICK_ANOTHER : Selection.SHOULD_SELECT }
         </span>
       </Button>
     )

--- a/src/mixins/__tests__/collection-test.js
+++ b/src/mixins/__tests__/collection-test.js
@@ -1,0 +1,70 @@
+jest.autoMockOff()
+
+describe('Collection Mixin', function() {
+  let Sync       = require('../sync')
+  let Collection = require('../collection')
+  let React      = require('react/addons')
+  let Test       = React.addons.TestUtils
+
+  function makeComponent() {
+    return React.createClass({
+      mixins: [ Collection ],
+      render: () => (<p />)
+    })
+  }
+
+  it ("fetches on mount", function() {
+    Sync.fetch = jest.genMockFunction()
+
+    let Component = makeComponent()
+    let component = Test.renderIntoDocument(<Component url="test" />)
+
+    expect(Sync.fetch).toBeCalled()
+  })
+
+  describe('responseDidSucceed', function() {
+    let Component = makeComponent()
+    let onFetch   = jest.genMockFunction();
+
+    it ("calls onFetch when a response succeeds", function() {
+      let component = Test.renderIntoDocument(<Component onFetch={ onFetch } />)
+
+      component.responseDidSucceed('body')
+
+      expect(onFetch).toBeCalledWith('body')
+    })
+
+    it ("sets the error state to false", function() {
+      let component = Test.renderIntoDocument(<Component onFetch={ onFetch } />)
+
+      component.responseDidSucceed()
+
+      expect(component.state.error).toEqual(false)
+    })
+
+    it ("sets the items state to the returned value of onFetch", function() {
+      let onFetch   = () => 'fetched';
+      let component = Test.renderIntoDocument(<Component onFetch={ onFetch } />)
+
+      component.responseDidSucceed()
+
+      expect(component.state.items).toEqual('fetched')
+    })
+
+  })
+
+  describe('responseDidFail', function() {
+    let Component = makeComponent()
+
+    it ("sets the error state to the returned value of onError", function() {
+      let onError   = (response) => `${ response } error!`
+      let component = Test.renderIntoDocument(<Component onError={ onError }/>)
+
+      component.responseDidFail('terrible')
+
+      expect(component.state.error).toEqual('terrible error!')
+    })
+
+  })
+
+})

--- a/src/mixins/__tests__/record-test.js
+++ b/src/mixins/__tests__/record-test.js
@@ -1,0 +1,84 @@
+jest.autoMockOff()
+
+describe('Record Mixin', function() {
+  let Sync   = require('../sync')
+  let Record = require('../record')
+  let React  = require('react/addons')
+  let Test   = React.addons.TestUtils
+
+  function makeComponent() {
+    return React.createClass({
+      mixins: [ Record ],
+      render: () => (<p />)
+    })
+  }
+
+  describe("componentWillMount", function() {
+
+    it ("fetches on mount if given a slug", function() {
+      Sync.fetch = jest.genMockFunction()
+
+      let Component = makeComponent()
+      let component = Test.renderIntoDocument(<Component url="test" slug="test" />)
+
+      expect(Sync.fetch).toBeCalledWith("test")
+    })
+
+    it ("does not fetch on mount if no slug is provided", function() {
+      Sync.fetch = jest.genMockFunction()
+
+      let Component = makeComponent()
+      let component = Test.renderIntoDocument(<Component url="test" />)
+
+      expect(Sync.fetch).not.toBeCalled()
+    })
+
+  })
+
+  describe('responseDidSucceed', function() {
+    let Component = makeComponent()
+    let onFetch   = jest.genMockFunction();
+
+    it ("calls onFetch when a response succeeds", function() {
+      let component = Test.renderIntoDocument(<Component onFetch={ onFetch } />)
+
+      component.responseDidSucceed('body')
+
+      expect(onFetch).toBeCalledWith('body')
+    })
+
+    it ("sets the error state to false", function() {
+      let component = Test.renderIntoDocument(<Component onFetch={ onFetch } />)
+
+      component.responseDidSucceed()
+
+      expect(component.state.error).toEqual(false)
+    })
+
+    it ("sets the item state to the returned value of onFetch", function() {
+      let onFetch   = () => 'fetched';
+      let component = Test.renderIntoDocument(<Component onFetch={ onFetch } />)
+
+      component.responseDidSucceed()
+
+      expect(component.state.item).toEqual('fetched')
+    })
+
+  })
+
+  describe('responseDidFail', function() {
+    let Component = makeComponent()
+
+    it ("sets the error state to the returned value of onError, and item to false", function() {
+      let onError   = (response) => `${ response } error!`
+      let component = Test.renderIntoDocument(<Component onError={ onError }/>)
+
+      component.responseDidFail('terrible')
+
+      expect(component.state.error).toEqual('terrible error!')
+      expect(component.state.item).toEqual(false)
+    })
+
+  })
+
+})

--- a/src/mixins/__tests__/sync-test.js
+++ b/src/mixins/__tests__/sync-test.js
@@ -71,12 +71,13 @@ describe('Sync Mixin', function() {
   describe('responseDidFail', function() {
     let Component = makeComponent()
 
-    it ("sets the error state to the response", function() {
-      let component = Test.renderIntoDocument(<Component />)
+    it ("sets the error state to the returned value of onError", function() {
+      let onError   = (response) => `${ response } error!`
+      let component = Test.renderIntoDocument(<Component onError={ onError }/>)
 
-      component.responseDidFail('terribly')
+      component.responseDidFail('terrible')
 
-      expect(component.state.error).toEqual('terribly')
+      expect(component.state.error).toEqual('terrible error!')
     })
 
   })

--- a/src/mixins/__tests__/sync-test.js
+++ b/src/mixins/__tests__/sync-test.js
@@ -12,72 +12,40 @@ describe('Sync Mixin', function() {
     })
   }
 
-  beforeEach(function() {
-    Sync = require('../sync')
-  })
-
   it ("has a default onFetch method", function() {
     let onFetch = Sync.getDefaultProps().onFetch
 
-    expect(onFetch(true)).toEqual(true)
+    expect(onFetch('success')).toEqual('success')
   })
 
-  it ("has a default urlBuilder method", function() {
-    let urlBuilder = Sync.getDefaultProps().urlBuilder
+  it ("has a default onError method", function() {
+    let onError = Sync.getDefaultProps().onError
 
-    expect(urlBuilder('route', 'query')).toEqual('route?q=query')
+    expect(onError('error')).toEqual('error')
   })
 
-  it ("fetches on mount", function() {
-    Sync.fetch = jest.genMockFunction();
+  describe('makeUrl', function() {
 
-    let Component = makeComponent()
-    let component = Test.renderIntoDocument(<Component url="test" />)
+    it ("returns a url when no slug is given", function() {
+      let makeURL = Sync.getDefaultProps().makeURL
 
-    expect(Sync.fetch).toBeCalled()
-  })
-
-  describe('responseDidSucceed', function() {
-    let Component = makeComponent()
-    let onFetch   = jest.genMockFunction();
-
-    it ("calls onFetch when a response succeeds", function() {
-      let component = Test.renderIntoDocument(<Component onFetch={ onFetch } />)
-
-      component.responseDidSucceed('body')
-
-      expect(onFetch).toBeCalledWith('body')
+      expect(makeURL('route')).toEqual('route')
     })
 
-    it ("sets the error state to false", function() {
-      let component = Test.renderIntoDocument(<Component onFetch={ onFetch } />)
+    it ("appends a slug when provided", function() {
+      let makeURL = Sync.getDefaultProps().makeURL
 
-      component.responseDidSucceed()
-
-      expect(component.state.error).toEqual(false)
-    })
-
-    it ("sets the items state to the returned value of onFetch", function() {
-      let onFetch   = () => 'fetched';
-      let component = Test.renderIntoDocument(<Component onFetch={ onFetch } />)
-
-      component.responseDidSucceed()
-
-      expect(component.state.items).toEqual('fetched')
+      expect(makeURL('route', 'fiz')).toEqual('route/fiz')
     })
 
   })
 
-  describe('responseDidFail', function() {
-    let Component = makeComponent()
+  describe('makeQuery', function() {
 
-    it ("sets the error state to the returned value of onError", function() {
-      let onError   = (response) => `${ response } error!`
-      let component = Test.renderIntoDocument(<Component onError={ onError }/>)
+    it ("constructs a query given a term", function() {
+      let makeQuery = Sync.getDefaultProps().makeQuery
 
-      component.responseDidFail('terrible')
-
-      expect(component.state.error).toEqual('terrible error!')
+      expect(makeQuery('term')).toEqual('q=term')
     })
 
   })

--- a/src/mixins/collection.js
+++ b/src/mixins/collection.js
@@ -1,0 +1,32 @@
+/**
+ * Collection Mixin
+ * Sync operations for a list of items
+ */
+
+import Sync from './sync'
+
+export default {
+
+  mixins: [ Sync ],
+
+  getInitialState() {
+    items : []
+  },
+
+  componentDidMount() {
+    this.fetch()
+  },
+
+  responseDidSucceed(response) {
+    let items = this.props.onFetch(response)
+
+    this.setState({ items, error: false })
+  },
+
+  responseDidFail(response) {
+    let error = this.props.onError(response)
+
+    this.setState({ error })
+  }
+
+}

--- a/src/mixins/record.js
+++ b/src/mixins/record.js
@@ -1,0 +1,46 @@
+/**
+ * Record Mixin
+ * Sync operations for a single record
+ */
+
+import Sync from "./sync"
+
+export default {
+
+  mixins: [ Sync ],
+
+  getInitialState() {
+    return {
+      item : false
+    }
+  },
+
+  fetchIf(slug) {
+    if (slug != undefined) {
+      this.fetch(slug)
+    }
+  },
+
+  componentWillMount() {
+    this.fetchIf(this.props.slug)
+  },
+
+  componentWillReceiveProps(props) {
+    if (props.slug !== this.props.slug) {
+      this.fetchIf(props.slug)
+    }
+  },
+
+  responseDidSucceed(response) {
+    let item = this.props.onFetch(response)
+
+    this.setState({ item, error: false })
+  },
+
+  responseDidFail(response) {
+    let error = this.props.onError(response)
+
+    this.setState({ item: false, error })
+  }
+
+}

--- a/src/mixins/sync.js
+++ b/src/mixins/sync.js
@@ -12,12 +12,14 @@ export default {
 
   propTypes: {
     buildQuery : Types.func,
+    onError    : Types.func,
     onFetch    : Types.func
   },
 
   getDefaultProps() {
     return {
       onFetch    : data => data,
+      onError    : response => response,
       urlBuilder : (url, query) => `${ url }?q=${ query }`
     }
   },
@@ -31,7 +33,7 @@ export default {
   },
 
   fetch() {
-    let url = this.props.urlBuilder(this.props.url, this.state.search)
+    let url = this.state.search? this.props.urlBuilder(this.props.url, this.state.search) : this.props.url
 
     if (this.state.request) {
       this.state.request.abort()
@@ -46,13 +48,15 @@ export default {
     this.fetch()
   },
 
-  responseDidSucceed(raw) {
-    let items = this.props.onFetch(raw)
+  responseDidSucceed(response) {
+    let items = this.props.onFetch(response)
 
     this.setState({ items, error: false })
   },
 
-  responseDidFail(error) {
+  responseDidFail(response) {
+    let error = this.props.onError(response)
+
     this.setState({ error })
   }
 

--- a/src/mixins/sync.js
+++ b/src/mixins/sync.js
@@ -12,10 +12,11 @@ let Types = React.PropTypes
 export default {
 
   propTypes: {
-    url        : Types.string.isRequired,
-    buildQuery : Types.func,
-    onError    : Types.func,
-    onFetch    : Types.func
+    url       : Types.string.isRequired,
+    makeQuery : Types.func,
+    makeURL   : Types.func,
+    onError   : Types.func,
+    onFetch   : Types.func
   },
 
   getDefaultProps() {

--- a/src/stores/photo.js
+++ b/src/stores/photo.js
@@ -14,12 +14,6 @@ let Photo = {
     })
 
     return request
-  },
-
-  find(items, id = false) {
-    if (!id) return null
-
-    return items.find(i => i.id.toString() === id.toString())
   }
 
 }

--- a/src/stores/photo.js
+++ b/src/stores/photo.js
@@ -20,10 +20,6 @@ let Photo = {
     if (!id) return null
 
     return items.find(i => i.id.toString() === id.toString())
-  },
-
-  datalist(items) {
-    return items.map(i => i.caption)
   }
 
 }

--- a/src/style/components/selection.scss
+++ b/src/style/components/selection.scss
@@ -25,3 +25,7 @@
   right: 0;
   width: 100%;
 }
+
+.ars-selection-photo + .ars-selection-caption {
+  border-radius: 0;
+}


### PR DESCRIPTION
This pull request does quite a lot.

`urlBuilder` is now `makeURL` and `makeQuery` in order to support single record retrieval.

I broke up Sync into two additional mixins: Collection, and Record. This allows the selection button preview image to fetch records separately from the main payload. This will be very useful when we add pagination, and also allows the Selection component to fetch a single record, instead of a huge list.

Additionally, the gallery is now responsible for fetching information itself. This cleans up a bit of code.

I also added a server to the example, allowing search to be testable.