### PR TITLE
Multiselect Cleanup

### DIFF
--- a/src/components/__tests__/ars-test.jsx
+++ b/src/components/__tests__/ars-test.jsx
@@ -13,10 +13,15 @@ describe("Ars", function() {
 
   describe("when the component renders", function() {
     let onChange  = sinon.spy()
-    let component = Test.renderIntoDocument(makeComponent({ onChange }))
+    let picked = 9
+    let component = Test.renderIntoDocument(makeComponent({ onChange, picked }))
 
     it ("has a selection component", function() {
       component.refs.should.have.property("selection")
+    })
+
+    it ("migrates a single `picked` value to an array", function() {
+      component.state.should.have.property("picked").that.deep.equals([picked])
     })
   })
 
@@ -30,10 +35,11 @@ describe("Ars", function() {
     })
 
     describe("and a gallery item is picked", function() {
-      component._onGalleryPicked([9, 12])
+      let picked = [9, 12]
+      component._onGalleryPicked(picked)
 
       it ("sets the `picked` state to an array of chosen values", function() {
-        component.state.should.have.property("picked").that.deep.equals([9, 12])
+        component.state.should.have.property("picked").that.deep.equals(picked)
       })
 
       it ("calls the onChange event with the picked state", function() {
@@ -47,11 +53,12 @@ describe("Ars", function() {
     describe("and an onChange handler is provided", function() {
       let onChange  = sinon.spy()
       let component = Test.renderIntoDocument(makeComponent({ onChange }))
+      let picked = [9]
 
-      component._onGalleryPicked([9])
+      component._onGalleryPicked(picked)
 
       it ("sets the `picked` state to an array of chosen values", function() {
-        component.state.should.have.property("picked").that.deep.equals([9])
+        component.state.should.have.property("picked").that.deep.equals(picked)
       })
 
       it ("calls the onChange event with the first item in the picked state", function() {

--- a/src/components/ars.jsx
+++ b/src/components/ars.jsx
@@ -25,9 +25,14 @@ let Ars = module.exports = React.createClass({
   },
 
   getInitialState() {
+    let { picked } = this.props
+    if (picked && !Array.isArray(picked)) {
+      picked = [picked]
+    }
+
     return {
       dialogOpen : false,
-      picked     : this.props.picked
+      picked     : picked
     }
   },
 
@@ -44,10 +49,11 @@ let Ars = module.exports = React.createClass({
     let { dialogOpen, picked } = this.state
     let SelectionComponent = this.props.multiselect ? MultiSelection : Selection
     let ref = SelectionComponent.displayName.toLowerCase()
+    let slug = this.props.multiselect ? picked : picked && picked[0]
 
     return (
       <div className="ars">
-        <SelectionComponent ref={ ref } { ...this.syncProps() } onClick={ this._onOpenClick } slug={ picked } />
+        <SelectionComponent ref={ ref } { ...this.syncProps() } onClick={ this._onOpenClick } slug={ slug } />
         { dialogOpen && this.getPicker() }
       </div>
     )

--- a/src/components/multiselection-item.jsx
+++ b/src/components/multiselection-item.jsx
@@ -3,7 +3,6 @@
  */
 
 let Button          = require('./ui/button')
-let SelectionFigure = require('./selection-figure')
 let Image           = require("./ui/image")
 let React           = require('react')
 let Record          = require('../mixins/record')


### PR DESCRIPTION
Fixes multiselect backwards-compatibility. Pre-existing 'single' values are converted to an array for more consistent handling.