### PR TITLE
Picker Modal `onExit`

### DIFF
--- a/src/components/ars.jsx
+++ b/src/components/ars.jsx
@@ -72,7 +72,8 @@ let Ars = module.exports = React.createClass({
     this.setState({ picked }, this._triggerChange)
   },
 
-  _onExit() {
+  _onExit(e) {
+    e && e.preventDefault();
     this.setState({ dialogOpen: false })
   }
 


### PR DESCRIPTION
Quick fix for a Picker modal bug that can occur when click events bubble.

The picker modal was immediately re-opening after clicking to close it with markup like this:

```jsx
<label>
  <Ars>
</label>
```