### PR TITLE
0.4 Style Updates

### DIFF
--- a/example/example.jsx
+++ b/example/example.jsx
@@ -19,6 +19,8 @@ let options = {
 }
 
 ArsArsenal.render(select, options);
+ArsArsenal.render(selectWithValue, Object.assign({ picked: [1]}, options));
 
 options.multiselect = true;
 ArsArsenal.render(multiselect, options);
+ArsArsenal.render(multiselectWithValue, Object.assign({ picked: [2,3]}, options));

--- a/example/index.html
+++ b/example/index.html
@@ -22,8 +22,14 @@
     <h1>Basic Use</h1>
     <div id="select"></div>
 
-    <h1>Selecting Multiples</h1>
+    <h1>Basic Use: Pre-selected</h1>
+    <div id="selectWithValue"></div>
+
+    <h1>Multiselect</h1>
     <div id="multiselect"></div>
+
+    <h1>Multiselect: Pre-selected</h1>
+    <div id="multiselectWithValue"></div>
 
     <script src="example.build.js"></script>
   </body>

--- a/src/components/multiselection.jsx
+++ b/src/components/multiselection.jsx
@@ -27,12 +27,14 @@ let MultiSelection = React.createClass({
 
   render() {
     let { slug } = this.props
+
     return (
       <div className="ars-multiselection">
         { this.getItems() }
 
         <Button ref="button" onClick={ this._onClick } className="ars-selection-edit">
           { slug && slug.length > 0 ? 'Pick different photos' : 'Pick photos' }
+          <span className="ars-selection-button-icon" aria-hidden="true"></span>
         </Button>
       </div>
     )

--- a/src/components/selection.jsx
+++ b/src/components/selection.jsx
@@ -17,6 +17,16 @@ let Selection = React.createClass({
     return item ? (<SelectionFigure ref="photo" item={ item } />) : null
   },
 
+  getButtonText() {
+    let text = 'Pick a photo'
+    if (this.state.fetching) {
+      text = 'Loading photo'
+    } else if (this.state.item) {
+      text = 'Pick a different photo'
+    }
+    return text
+  },
+
   render() {
     let className = cx('ars-selection', {
       'ars-is-loading': this.state.fetching,
@@ -29,7 +39,8 @@ let Selection = React.createClass({
           { this.getPhoto() }
 
           <Button ref="button" onClick={ this._onClick } className="ars-selection-edit">
-            { this.state.item ? 'Pick a different photo' : 'Pick a photo' }
+            { this.getButtonText() }
+            <span className="ars-selection-button-icon" aria-hidden="true"></span>
           </Button>
         </div>
       </div>

--- a/src/components/ui/__tests__/image-test.jsx
+++ b/src/components/ui/__tests__/image-test.jsx
@@ -9,7 +9,9 @@ describe('Image Component', function() {
 
     Test.Simulate.load(component.getDOMNode())
 
-    component.state.should.have.property('isLoaded', true)
+    setTimeout(function() {
+      component.state.should.have.property('isLoaded', true)
+    }, Image.ONLOAD)
   })
 
   it ('adds an error class on failed images', function() {

--- a/src/components/ui/image.jsx
+++ b/src/components/ui/image.jsx
@@ -9,6 +9,10 @@ let cx    = require('classnames')
 
 let Image = React.createClass({
 
+  statics: {
+    ONLOAD: 10
+  },
+
   propTypes: {
     src: React.PropTypes.string
   },
@@ -43,7 +47,7 @@ let Image = React.createClass({
   },
 
   _onLoad() {
-    this.setState({ didFail: false, isLoaded: true })
+    setTimeout(() => this.setState({ didFail: false, isLoaded: true }), Image.ONLOAD)
   },
 
   _onError() {

--- a/src/style/components/image.scss
+++ b/src/style/components/image.scss
@@ -7,6 +7,7 @@ $ars-failed-size : 25px;
   opacity: 0.1;
   height: 100%;
   transition: 2.5s filter $ars-img-easing, 2.5s opacity $ars-img-easing;
+  -webkit-transition: 2.5s -webkit-filter $ars-img-easing, 2.5s opacity $ars-img-easing;
   user-select: none;
   width: 100%;
 }
@@ -14,6 +15,11 @@ $ars-failed-size : 25px;
 .ars-img-loaded {
   filter: none;
   opacity: 1;
+}
+
+.ars-is-loading .ars-img-loaded {
+  filter: brightness(1.25) saturate(0.2);
+  opacity: 0.1;
 }
 
 .ars-img-failed {

--- a/src/style/components/selection.scss
+++ b/src/style/components/selection.scss
@@ -6,7 +6,6 @@
   margin: 0;
   padding: 0;
   position: relative;
-  transition: 0.75s border-radius, 0.3s height, 0.3s width;
 
   .ink {
     color: $ars-primary;
@@ -18,30 +17,25 @@
   }
 
   &.ars-is-loading {
-    animation: 0.7s ars-spin infinite;
-    animation-timing-function: linear;
-    background: url('/icons/refresh.svg') 50% 50% no-repeat;
-    border-radius: 50%;
-    box-shadow: 0 0 1px rgba(#000, 0.12);
-    height: 48px;
-    overflow: hidden;
-    transition: 0.3s border-radius;
-    width: 48px;
+    .ars-selection-desc {
+      opacity: 0.2;
+    }
+
+    .ars-selection-button-icon {
+      animation: 0.7s ars-spin infinite;
+      animation-timing-function: linear;
+      background-image: url('/icons/refresh.svg');
+    }
   }
-}
-
-.ars-selection-inner {
-  transition: 0.4s all 0.75s;
-}
-
-.ars-is-loading .ars-selection-inner {
-  transition: 0.2s all;
-  opacity: 0;
 }
 
 .ars-selection-photo {
   display: block;
   max-height: 225px;
+}
+
+.ars-selection-desc {
+  transition: 0.55s opacity;
 }
 
 .ars-selection-title {
@@ -75,11 +69,18 @@
 }
 
 .ars-button.ars-selection-edit {
-  background: url('/icons/edit.svg') calc(100% - 16px) 50% no-repeat;
   display: block;
   margin: 0;
-  padding: 16px 48px 16px 16px;
-  text-align: right;
-  transition: 0.3s all;
+  padding: 16px;
+  text-align: center;
   width: 100%;
+}
+
+.ars-selection-button-icon {
+  background: url('/icons/edit.svg') 50% 50% no-repeat;
+  display: inline-block;
+  height: 18px;
+  margin-left: 12px;
+  vertical-align: text-bottom;
+  width: 18px;
 }


### PR DESCRIPTION
Updates basic selection styles, adds pre-selected options to example. The main goal was to make it even easier to drop into Colonel Kurtz blocks.

* Centers selection text, re-positions icons to reflect the loading state within the selection button.
* Adds "Loading photo" text while a selected image is fetching.
* Applies the "loaded" class to the image shortly after onload for image-to-image transitions.
* Adds an explicit `-webkit-transition` to workaround autoprefixr using `filter` instead of `-webkit-filter` as a transition property.

![ars](https://cloud.githubusercontent.com/assets/1019830/10486370/a6b96bb0-725c-11e5-8396-2f7203fcbc7f.gif)

I wanted to make a similar update to multiselection, but it looks like state needs to move for that to occur. Possibly something to tackle later this week.