### PR TITLE
[update] send objects, not ids, to `onChange`

### DIFF
--- a/example/example.jsx
+++ b/example/example.jsx
@@ -2,9 +2,9 @@ let ArsArsenal = require('../src/index')
 
 require('./style')
 
-let onSingleChange = function(value) {
-  alert("You selected " + value.name)
-  console.log("Value changed to %s", value.id);
+let onSingleChange = function(object) {
+  alert("You selected " + object.name)
+  console.log("Value changed to %s", object.id);
 }
 
 let options = {
@@ -18,12 +18,12 @@ let options = {
     return `${ response.code }: ${ response.message }`;
   },
 
-  onChange(value) {
-    if (Array.isArray(value)) {
-      return value.forEach(onSingleChange)
+  onChange(ids, objects) {
+    if (Array.isArray(objects)) {
+      return objects.forEach(onSingleChange)
     }
 
-    onSingleChange(value)
+    onSingleChange(objects)
   }
 }
 

--- a/example/example.jsx
+++ b/example/example.jsx
@@ -2,9 +2,14 @@ let ArsArsenal = require('../src/index')
 
 require('./style')
 
-let options = {
-  url: `http://${ window.location.hostname }:7654/photos`,
+let onSingleChange = function(value) {
+  alert("You selected " + value.name)
+  console.log("Value changed to %s", value.id);
+}
 
+let options = {
+  picked    : 1,
+  url: `http://${ window.location.hostname }:7654/photos`,
   makeQuery(term) {
     return `term=${ term }`
   },
@@ -14,7 +19,11 @@ let options = {
   },
 
   onChange(value) {
-    console.log("Value changed to %s", value);
+    if (Array.isArray(value)) {
+      return value.forEach(onSingleChange)
+    }
+
+    onSingleChange(value)
   }
 }
 

--- a/src/components/ars.jsx
+++ b/src/components/ars.jsx
@@ -61,7 +61,12 @@ let Ars = module.exports = React.createClass({
 
   _triggerChange() {
     let { picked } = this.state
-    this.props.onChange(this.props.multiselect ? picked : picked[0])
+    if (this.props.multiselect) {
+      let pickedIds = picked.map((item) => item.id)
+      this.props.onChange(pickedIds, picked)
+    } else {
+      this.props.onChange(picked[0].id, picked[0])
+    }
   },
 
   _onOpenClick() {

--- a/src/components/figure.jsx
+++ b/src/components/figure.jsx
@@ -35,7 +35,7 @@ let Figure = React.createClass({
 
   _onClick(e) {
     e.preventDefault()
-    this.props.onClick(this.props.record.id)
+    this.props.onClick(this.props.record)
   }
 
 })

--- a/src/components/gallery.jsx
+++ b/src/components/gallery.jsx
@@ -23,7 +23,15 @@ let Gallery = React.createClass({
   },
 
   getItem(record) {
-    let isPicked = this.props.picked ? this.props.picked.indexOf(record.id) !== -1 : false
+    let pickedItemIds = []
+
+    if (this.props.picked) {
+      pickedItemIds = this.props.picked.map((item) => {
+        return(item.id || item)
+      })
+    }
+
+    let isPicked = pickedItemIds.indexOf(record.id) !== -1
 
     return (
       <div className="ars-gallery-item" key={ 'photo_' + record.id } >

--- a/src/mixins/collection.js
+++ b/src/mixins/collection.js
@@ -26,7 +26,16 @@ module.exports = {
   responseDidSucceed(response) {
     let items = this.props.onFetch(response)
 
-    this.setState({ items, error: false })
+    // This is a total freakin' hack. Change it. - @ltk
+    let picked = this.state.picked.map((item) => {
+      if(typeof item === 'number') {
+        return items.find((itemObject) => itemObject.id === item)
+      } else {
+        return item
+      }
+    })
+
+    this.setState({ items, picked, error: false })
   },
 
   responseDidFail(response) {

--- a/src/mixins/sync.js
+++ b/src/mixins/sync.js
@@ -7,6 +7,12 @@ let React = require("react")
 let XHR   = require('xhr')
 let Types = React.PropTypes
 
+let defaultMakeURL = function(url, item) {
+  let id = null
+  if (item) id = item.id || item
+  return(url + (id ? "/" + id : ""))
+}
+
 let Sync = {
 
   propTypes: {
@@ -20,7 +26,7 @@ let Sync = {
   getDefaultProps() {
     return {
       makeQuery : (query) => `q=${ query }`,
-      makeURL   : (url, id = false) => url + (id ? "/" + id : ""),
+      makeURL   : defaultMakeURL,
       onError   : response => response,
       onFetch   : data => data
     }


### PR DESCRIPTION
_This is a proof-of-concept PR._ I just wanted to get people's opinions about whether or not this is a direction consistent with the project roadmap. If it is, I'll seriously clean this up and test it.

Just receiving a chosen item's ID within `onChange` is extremely limiting. You can get hacky and pass non-ID attributes to `onChange` by changing the ID attribute with the `onFetch` callback, but this breaks the library's API interactions if the endpoints actually require the item's real ID. This PR exposes the actual item object, instead of it's ID to `onChange`. As demonstrated, this change can be implemented in a way that minimally affects the library's public API.

The need for non-ID attributes arose during some work I'm doing around referential integrity of Colonel Kurtz content. We want to start referencing records by [SGID](https://github.com/rails/globalid/blob/1d8fca667740570d204fd955a0bd39ac539bac7f/lib/global_id/signed_global_id.rb) within the CK JSON, instead of by ID.

![demo](https://s3.amazonaws.com/vigesharing-is-vigecaring/lkurtz/ars-arsenal-object-return.gif)
