### PR TITLE
Image Component isLoaded fix

### DIFF
--- a/src/components/ui/__tests__/image-test.jsx
+++ b/src/components/ui/__tests__/image-test.jsx
@@ -21,4 +21,31 @@ describe('Image Component', function() {
 
     component.state.should.have.property('didFail', true)
   })
+
+  it ('resets its loaded state when a new src is received', function() {
+    let parentComponent = React.createFactory(React.createClass({
+      getInitialState() {
+        return {
+          url: 'foo.jpg'
+        }
+      },
+      render() {
+        return <Image ref="image" src={ this.state.url } />
+      }
+    }))
+
+    let component = Test.renderIntoDocument(parentComponent())
+    let image = component.refs.image
+
+    image.props.src.should.equal('foo.jpg')
+    image.state.isLoaded.should.equal(false)
+
+    component.setState({
+      isLoaded: true,
+      url: 'bar.jpg'
+    })
+
+    image.props.src.should.equal('bar.jpg')
+    image.state.isLoaded.should.equal(false)
+  })
 })

--- a/src/components/ui/image.jsx
+++ b/src/components/ui/image.jsx
@@ -30,6 +30,14 @@ let Image = React.createClass({
     }
   },
 
+  componentWillReceiveProps(nextProps) {
+    let { src } = this.props
+
+    if (nextProps.src !== src) {
+      this.setState({ isLoaded: false })
+    }
+  },
+
   render() {
     let { className, ...props} = this.props
 


### PR DESCRIPTION
Resets the `isLoaded` state to false when the image re-renders with a different src.