### PR TITLE
Custom Resource Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ var app = document.getElementById('app')
 
 ArsArsenal.render(app, {
 
+  resource: 'photo', // the noun used for selection, i.e. "Pick a photo"
+
   url: 'photo/resource/endpoint',
+
+  multiselect: false,
 
   makeURL: function (url, id) {
     // define how the endpoint url is constructed

--- a/src/components/__tests__/multiselection-test.jsx
+++ b/src/components/__tests__/multiselection-test.jsx
@@ -5,26 +5,18 @@ let Test = React.addons.TestUtils
 describe('MultiSelection', function() {
 
   describe('when given photos', function() {
-    let component = Test.renderIntoDocument(<MultiSelection slug={ [0, 1] } url="/base/test/test.json" />)
+    let component = Test.renderIntoDocument(<MultiSelection slug={ [0, 1] } url="/base/test/test.json" resource="Photo" />)
 
     it ('renders photos', function() {
       component.getDOMNode().querySelector('.ars-multiselection-grid').should.exist
     })
-
-    it ('has button to pick different photos', function() {
-      component.refs.button.getDOMNode().textContent.should.equal('Pick different photos')
-    })
   })
 
   describe('when not given photos', function() {
-    let component = Test.renderIntoDocument(<MultiSelection slug={ [] } url="/base/test/test.json" />)
+    let component = Test.renderIntoDocument(<MultiSelection slug={ [] } url="/base/test/test.json" resource="Photo" />)
 
     it ('does not render photos', function() {
       (component.getDOMNode().querySelector('.ars-multiselection-grid') === null).should.be.true
-    })
-
-    it ('has button to pick photos', function() {
-      component.refs.button.getDOMNode().textContent.should.equal('Pick photos')
     })
   })
 })

--- a/src/components/__tests__/selection-figure-test.jsx
+++ b/src/components/__tests__/selection-figure-test.jsx
@@ -1,0 +1,38 @@
+import SelectionFigure from '../selection-figure'
+
+let Test = React.addons.TestUtils
+
+describe('SelectionFigure', function() {
+
+  describe('when given a name', function() {
+    it ('renders a title', function() {
+      let component = Test.renderIntoDocument(<SelectionFigure item={ { name: 'Ars' } } />)
+
+      component.refs.should.have.property('title')
+    })
+  })
+
+  describe('when not given a name', function() {
+    it ('does not render a title', function() {
+      let component = Test.renderIntoDocument(<SelectionFigure item={ {} } />)
+
+      component.refs.should.not.have.property('title')
+    })
+  })
+
+  describe('when given a caption', function() {
+    it ('renders a caption', function() {
+      let component = Test.renderIntoDocument(<SelectionFigure item={ { caption: 'Ars' } } />)
+
+      component.refs.should.have.property('caption')
+    })
+  })
+
+  describe('when not given a caption', function() {
+    it ('does not render a caption', function() {
+      let component = Test.renderIntoDocument(<SelectionFigure item={ {} } />)
+
+      component.refs.should.not.have.property('caption')
+    })
+  })
+})

--- a/src/components/__tests__/selection-test.jsx
+++ b/src/components/__tests__/selection-test.jsx
@@ -6,7 +6,7 @@ describe('Selection', function() {
 
   describe('when given an item', function() {
     it ('renders a photo', function() {
-      let component = Test.renderIntoDocument(<Selection url="/base/test/test.json" />)
+      let component = Test.renderIntoDocument(<Selection url="/base/test/test.json" resource="Photo" />)
 
       component.setState({ item : { url: '/base/test/test.jpg' } })
 
@@ -16,7 +16,7 @@ describe('Selection', function() {
 
   describe('when not given an item', function() {
     it ('does not render a photo', function() {
-      let component = Test.renderIntoDocument(<Selection url="/base/test/test.json" />)
+      let component = Test.renderIntoDocument(<Selection url="/base/test/test.json" resource="Photo" />)
 
       component.refs.should.not.have.property('photo')
     })

--- a/src/components/__tests__/selection-text-test.jsx
+++ b/src/components/__tests__/selection-text-test.jsx
@@ -1,0 +1,58 @@
+import SelectionText from '../selection-text'
+
+let Test      = React.addons.TestUtils
+let item      = {}
+let fetching  = true
+let isPlural = true
+
+function makeComponent(props = {}) {
+  props.resource = props.resource || 'Image'
+
+  return (
+    <SelectionText { ...props } />
+  )
+}
+
+describe('SelectionText', function() {
+
+  describe('when the selection is empty', function() {
+    let component = Test.renderIntoDocument(makeComponent())
+
+    it ('has the correct text', function() {
+      expect(component.getDOMNode().textContent).to.equal('Pick an image')
+    })
+  })
+
+  describe('when the selection is not empty', function() {
+    let component = Test.renderIntoDocument(makeComponent({ item }))
+
+    it ('has the correct text', function() {
+      expect(component.getDOMNode().textContent).to.equal('Pick a different image')
+    })
+  })
+
+  describe('when the selection is loading', function() {
+    let component = Test.renderIntoDocument(makeComponent({ fetching }))
+
+    it ('has the correct text', function() {
+      expect(component.getDOMNode().textContent).to.equal('Loading image')
+    })
+  })
+
+  describe('when the selection is empty and the resource is plural', function() {
+    let component = Test.renderIntoDocument(makeComponent({ isPlural }))
+
+    it ('has the correct text', function() {
+      expect(component.getDOMNode().textContent).to.equal('Pick images')
+    })
+  })
+
+  describe('when the selection is not empty and the resource is plural', function() {
+    let component = Test.renderIntoDocument(makeComponent({ isPlural, item }))
+
+    it ('has the correct text', function() {
+      expect(component.getDOMNode().textContent).to.equal('Pick different images')
+    })
+  })
+
+})

--- a/src/components/__tests__/selection-text-test.jsx
+++ b/src/components/__tests__/selection-text-test.jsx
@@ -1,8 +1,8 @@
 import SelectionText from '../selection-text'
 
-let Test      = React.addons.TestUtils
-let item      = {}
-let fetching  = true
+let Test     = React.addons.TestUtils
+let item     = {}
+let fetching = true
 let isPlural = true
 
 function makeComponent(props = {}) {

--- a/src/components/ars.jsx
+++ b/src/components/ars.jsx
@@ -20,7 +20,8 @@ let Ars = module.exports = React.createClass({
   getDefaultProps() {
     return {
       onChange    : () => {},
-      multiselect : false
+      multiselect : false,
+      resource    : 'Photo'
     }
   },
 
@@ -53,7 +54,7 @@ let Ars = module.exports = React.createClass({
 
     return (
       <div className="ars">
-        <SelectionComponent ref={ ref } { ...this.syncProps() } onClick={ this._onOpenClick } slug={ slug } />
+        <SelectionComponent ref={ ref } { ...this.syncProps() } resource={ this.props.resource } onClick={ this._onOpenClick } slug={ slug } />
         { dialogOpen && this.getPicker() }
       </div>
     )

--- a/src/components/multiselection.jsx
+++ b/src/components/multiselection.jsx
@@ -4,6 +4,7 @@
 
 let Button             = require('./ui/button')
 let MultiSelectionItem = require('./multiselection-item')
+let SelectionText      = require('./selection-text')
 let React              = require('react')
 let Types              = React.PropTypes
 let cx                 = require('classnames')
@@ -11,6 +12,7 @@ let cx                 = require('classnames')
 let MultiSelection = React.createClass({
 
   propTypes: {
+    resource: React.PropTypes.string.isRequired,
     slug: Types.array
   },
 
@@ -33,7 +35,7 @@ let MultiSelection = React.createClass({
         { this.getItems() }
 
         <Button ref="button" onClick={ this._onClick } className="ars-selection-edit">
-          { slug && slug.length > 0 ? 'Pick different photos' : 'Pick photos' }
+          <SelectionText resource={ this.props.resource } item={ slug && slug.length > 0 } isPlural={ true } />
           <span className="ars-selection-button-icon" aria-hidden="true"></span>
         </Button>
       </div>

--- a/src/components/selection-figure.jsx
+++ b/src/components/selection-figure.jsx
@@ -20,12 +20,12 @@ let SelectionFigure = React.createClass({
 
   getTitle(title='') {
     let trimmed = title.trim()
-    return trimmed.length ? (<p className="ars-selection-title">{ trimmed }</p>) : null
+    return trimmed.length ? (<p ref="title" className="ars-selection-title">{ trimmed }</p>) : null
   },
 
   getCaption(caption='') {
     let trimmed = caption.trim()
-    return trimmed.length ? (<p className="ars-selection-caption">{ trimmed }</p>) : null
+    return trimmed.length ? (<p ref="caption" className="ars-selection-caption">{ trimmed }</p>) : null
   },
 
   render() {

--- a/src/components/selection-text.jsx
+++ b/src/components/selection-text.jsx
@@ -1,0 +1,62 @@
+/**
+ * SelectionText
+ */
+
+let React = require('react')
+let articleFor = require('../utils/article-for')
+let pluralize = require('../utils/pluralize')
+
+let SelectionText = React.createClass({
+
+  propTypes: {
+    resource : React.PropTypes.string.isRequired
+  },
+
+  getNoun(resource, isPlural = false) {
+    let noun = resource.toLowerCase()
+
+    if (isPlural) {
+      noun = pluralize(noun)
+    }
+
+    return noun
+  },
+
+  getEmptyText(article, noun, isPlural) {
+    let a = isPlural ? ' ' : ` ${ article } `
+    return `Pick${ a }${ noun }`
+  },
+
+  getSelectedText(noun, isPlural) {
+    let a = isPlural ? ' ' : ' a '
+    return `Pick${ a }different ${ noun }`
+  },
+
+  getLoadingText(noun) {
+    return `Loading ${ noun }`
+  },
+
+  getText() {
+    let { resource, fetching, item, isPlural } = this.props
+    let noun = this.getNoun(resource, isPlural)
+
+    if (fetching) {
+      return this.getLoadingText(noun)
+    } else if (item) {
+      return this.getSelectedText(noun, isPlural)
+    } else {
+      return this.getEmptyText(articleFor(noun), noun, isPlural)
+    }
+  },
+
+  render() {
+    return (
+      <span>
+        { this.getText() }
+      </span>
+    )
+  }
+
+})
+
+module.exports = SelectionText

--- a/src/components/selection.jsx
+++ b/src/components/selection.jsx
@@ -4,27 +4,22 @@
 
 let Button          = require('./ui/button')
 let SelectionFigure = require('./selection-figure')
+let SelectionText   = require('./selection-text')
 let React           = require('react')
 let Record          = require('../mixins/record')
 let cx              = require('classnames')
 
 let Selection = React.createClass({
 
+  propTypes: {
+    resource: React.PropTypes.string.isRequired
+  },
+
   mixins: [ Record ],
 
   getPhoto() {
     let { item } = this.state
     return item ? (<SelectionFigure ref="photo" item={ item } />) : null
-  },
-
-  getButtonText() {
-    let text = 'Pick a photo'
-    if (this.state.fetching) {
-      text = 'Loading photo'
-    } else if (this.state.item) {
-      text = 'Pick a different photo'
-    }
-    return text
   },
 
   render() {
@@ -39,7 +34,7 @@ let Selection = React.createClass({
           { this.getPhoto() }
 
           <Button ref="button" onClick={ this._onClick } className="ars-selection-edit">
-            { this.getButtonText() }
+            <SelectionText resource={ this.props.resource } { ...this.state } />
             <span className="ars-selection-button-icon" aria-hidden="true"></span>
           </Button>
         </div>

--- a/src/components/ui/image.jsx
+++ b/src/components/ui/image.jsx
@@ -39,7 +39,7 @@ let Image = React.createClass({
   },
 
   render() {
-    let { className, ...props} = this.props
+    let { className, ...props } = this.props
 
     let css = cx({
       'ars-img'        : true,

--- a/src/utils/__tests__/article-for-test.js
+++ b/src/utils/__tests__/article-for-test.js
@@ -1,0 +1,8 @@
+import articleFor from '../article-for'
+
+describe('articleFor', function() {
+  it ('returns the article preceeding the given noun', function() {
+    expect(articleFor('photo')).to.equal('a')
+    expect(articleFor('image')).to.equal('an')
+  })
+})

--- a/src/utils/__tests__/pluralize-test.js
+++ b/src/utils/__tests__/pluralize-test.js
@@ -1,0 +1,8 @@
+import pluralize from '../pluralize'
+
+describe('pluralize', function() {
+  it ('pluralizes a string', function() {
+    expect(pluralize('photo')).to.equal('photos')
+    expect(pluralize('photos')).to.equal('photos')
+  })
+})

--- a/src/utils/article-for.js
+++ b/src/utils/article-for.js
@@ -1,0 +1,15 @@
+/*
+ * A simplified take on which article to use before a noun.
+ * "A" goes before words that begin with consonants.
+ * "An" goes before words that begin with vowels.
+ */
+module.exports = function(noun) {
+  let article      = 'a'
+  const vowels     = ['a', 'e', 'i', 'o', 'u']
+
+  if (vowels.indexOf(noun[0].toLowerCase()) !== -1) {
+    article = 'an'
+  }
+
+  return article
+}

--- a/src/utils/pluralize.js
+++ b/src/utils/pluralize.js
@@ -1,0 +1,3 @@
+module.exports = function(word) {
+  return word.replace(/s?$/i, 's')
+}


### PR DESCRIPTION
Adds a new `resource` option for customizing the resource type language. This option applies to the "photo" reference in "Pick a photo" selection text. /cc @h0tl33t 

For example:
* Setting resource to "File" renders "Pick a file"
* Setting resource to "Image" renders "Pick an image"

Default example:

![screen shot 2015-10-20 at 3 14 57 pm](https://cloud.githubusercontent.com/assets/1019830/10618372/98ed2cde-773d-11e5-925b-8f75c95f6285.png)

---

With option `resource: 'Image'`:

![screen shot 2015-10-20 at 3 15 33 pm](https://cloud.githubusercontent.com/assets/1019830/10618381/9e28e0b2-773d-11e5-80ba-8633c59ae59b.png)
