### PR TITLE
Handle when null is passed into caption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.5.1
+
+- Handle `null` in captions and titles
+
 ## 2.5.0
 
 - Export project as CommonJS module for better support

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ars-arsenal",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "private": true,
   "description": "A gallery picker",
   "main": "src/index.js",

--- a/src/components/__tests__/selection-figure-test.js
+++ b/src/components/__tests__/selection-figure-test.js
@@ -14,6 +14,14 @@ describe('SelectionFigure', () => {
   })
 
   describe('when not given a name', () => {
+    test('handles null', () => {
+      let component = TestUtils.renderIntoDocument(
+        <SelectionFigure item={{ title: null }} />
+      )
+
+      expect(component.refs).not.toHaveProperty('title')
+    })
+
     test('does not render a title', () => {
       let component = TestUtils.renderIntoDocument(
         <SelectionFigure item={{}} />
@@ -34,6 +42,14 @@ describe('SelectionFigure', () => {
   })
 
   describe('when not given a caption', () => {
+    test('handles null', () => {
+      let component = TestUtils.renderIntoDocument(
+        <SelectionFigure item={{ caption: null }} />
+      )
+
+      expect(component.refs).not.toHaveProperty('caption')
+    })
+
     test('does not render a caption', () => {
       let component = TestUtils.renderIntoDocument(
         <SelectionFigure item={{}} />

--- a/src/components/selection-figure.js
+++ b/src/components/selection-figure.js
@@ -14,8 +14,8 @@ let SelectionFigure = createClass({
     }
   },
 
-  getTitle(title = '') {
-    let trimmed = title.trim()
+  getTitle(title) {
+    let trimmed = title ? title.trim() : ''
     return trimmed.length
       ? <p ref="title" className="ars-selection-title">
           {trimmed}
@@ -23,8 +23,8 @@ let SelectionFigure = createClass({
       : null
   },
 
-  getCaption(caption = '') {
-    let trimmed = caption.trim()
+  getCaption(caption) {
+    let trimmed = caption ? caption.trim() : ''
     return trimmed.length
       ? <p ref="caption" className="ars-selection-caption">
           {trimmed}


### PR DESCRIPTION
I have a project that is giving ArsArsenal `null` for the caption. When this happens, the component fails to render. Also taking care of `title` since it looks to be handled the same way.