### PR TITLE
Allow root element's attributes to be set via props

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ ArsArsenal.render(app, {
 
   resource: 'photo', // the noun used for selection, i.e. "Pick a photo"
 
+  // Configure the root element's HTML attributes. default = {}
   rootAttributes: {
     className: 'my-custom-class another-custom-class',
     'data-test': 'my-integration-selector-helper'

--- a/README.md
+++ b/README.md
@@ -44,11 +44,16 @@ ArsArsenal.render(app, {
 
   resource: 'photo', // the noun used for selection, i.e. "Pick a photo"
 
+  rootAttributes: {
+    className: 'my-custom-class another-custom-class',
+    'data-test': 'my-integration-selector-helper'
+  },
+
   url: 'photo/resource/endpoint',
-  
+
   // How to display the items. Can be "table" or "gallery"
   mode: 'gallery',
-  
+
   // What table columns to display, and in what order
   columns: ['id', 'name', 'caption', 'attribution', 'preview'],
 

--- a/src/components/__tests__/ars-test.js
+++ b/src/components/__tests__/ars-test.js
@@ -22,6 +22,13 @@ describe('Ars', () => {
     test('migrates a single `picked` value to an array', () => {
       expect(component.state.picked).toEqual([picked])
     })
+
+    test('has a data-test attribute', () => {
+      const htmlNode = TestUtils.findRenderedDOMComponentWithClass(component, 'ars')
+      const testAttr = htmlNode.attributes['data-test'].value
+
+      expect(testAttr).toEqual('ars-resource-Photo')
+    })
   })
 
   describe('when the component renders with the multiselect option', () => {

--- a/src/components/__tests__/ars-test.js
+++ b/src/components/__tests__/ars-test.js
@@ -22,12 +22,24 @@ describe('Ars', () => {
     test('migrates a single `picked` value to an array', () => {
       expect(component.state.picked).toEqual([picked])
     })
+  })
 
-    test('has a data-test attribute', () => {
-      const htmlNode = TestUtils.findRenderedDOMComponentWithClass(component, 'ars')
+  describe('when rootAttributes is provided', () => {
+    let onChange = jest.fn()
+    let picked = 9
+
+    test('can be given a root attribute', () => {
+      const rootAttributes = {
+        'data-test': 'ars-resource-photo',
+        className: 'my-custom-class'
+      }
+      let component = TestUtils.renderIntoDocument(
+        makeComponent({ onChange, picked, rootAttributes })
+      )
+      const htmlNode = TestUtils.findRenderedDOMComponentWithClass(component, 'my-custom-class')
       const testAttr = htmlNode.attributes['data-test'].value
 
-      expect(testAttr).toEqual('ars-resource-Photo')
+      expect(testAttr).toEqual('ars-resource-photo')
     })
   })
 

--- a/src/components/ars.js
+++ b/src/components/ars.js
@@ -67,7 +67,7 @@ let Ars = createClass({
     let slug = this.props.multiselect ? picked : picked && picked[0]
 
     return (
-      <div className="ars">
+      <div className="ars" data-test={`ars-resource-${resource}`}>
         <SelectionComponent
           ref={ref}
           {...this.syncProps()}

--- a/src/components/ars.js
+++ b/src/components/ars.js
@@ -9,6 +9,7 @@ import Selection from './selection'
 import MultiSelection from './multiselection'
 import Sync from '../mixins/sync'
 import createClass from 'create-react-class'
+import cx from 'classnames'
 import { func } from 'prop-types'
 
 let Ars = createClass({
@@ -21,6 +22,7 @@ let Ars = createClass({
   getDefaultProps() {
     return {
       onChange: () => {},
+      rootAttributes: {},
       multiselect: false,
       resource: 'Photo',
       mode: 'gallery'
@@ -59,15 +61,17 @@ let Ars = createClass({
   },
 
   render() {
-    const { multiselect, resource } = this.props
+    const { multiselect, resource, rootAttributes } = this.props
     const { dialogOpen, picked } = this.state
 
     let SelectionComponent = multiselect ? MultiSelection : Selection
     let ref = multiselect ? 'multiselection' : 'selection'
     let slug = this.props.multiselect ? picked : picked && picked[0]
+    const rootClass = cx('ars', rootAttributes.className)
+    delete rootAttributes.className
 
     return (
-      <div className="ars" data-test={`ars-resource-${resource}`}>
+      <div className={rootClass} {...rootAttributes}>
         <SelectionComponent
           ref={ref}
           {...this.syncProps()}

--- a/src/components/ars.js
+++ b/src/components/ars.js
@@ -68,10 +68,9 @@ let Ars = createClass({
     let ref = multiselect ? 'multiselection' : 'selection'
     let slug = this.props.multiselect ? picked : picked && picked[0]
     const rootClass = cx('ars', rootAttributes.className)
-    delete rootAttributes.className
 
     return (
-      <div className={rootClass} {...rootAttributes}>
+      <div {...rootAttributes} className={rootClass}>
         <SelectionComponent
           ref={ref}
           {...this.syncProps()}


### PR DESCRIPTION
# Problem
For applications that instantiate multiple Ars Arsenal pickers, I'm finding it difficult to scope integration tests (using tools like Ruby's Capybara) to the picker for the item I'm concerned about.

# Solution
Add a `rootAttributes` prop that defaults to `{}`. Spread those rootAttributeses onto the root `<div>` element that allows users to pass in what they'd like, including classes.

For example, when instantiating:
```javascript
ArsArsenal.render(app, {
  resource: 'photo',
  rootAttributes: {
    className: 'my-custom-class another-custom-class',
    'data-test': 'my-integration-selector-helper'
  }
  // ...
})
```

Will result in an element with

```html
<div class="ars my-custom-class another-custom-class" data-test="my-integration-selector-helper">
  <!-- Ars Arsenal stuff here -->
</div>
```

And I can test it with integration test libraries like Capybara as such:

```ruby
within('div.ars[data-test="my-integration-selector-helper"]') do
  click_on "Pick photos"
  captions.each { |item| click_on item }
  click_on 'Okay'
end
```