### PR TITLE
Modernize Button component

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,9 +47,7 @@
     ],
     "no-unused-vars": [
       1,
-      {
-        "args": "none"
-      }
+      { "args": "none", "ignoreRestSiblings": true, "varsIgnorePattern": "^_" }
     ],
     "react/jsx-equals-spacing": [
       "warn",

--- a/src/components/ui/button.js
+++ b/src/components/ui/button.js
@@ -1,33 +1,38 @@
 /**
  * Button
+ * @flow
  */
 
 import Ink from 'react-ink'
 import React from 'react'
 import cx from 'classnames'
-import createClass from 'create-react-class'
 
-let Button = createClass({
-  getDefaultProps() {
-    return {
-      raised: false,
-      type: 'button'
-    }
-  },
+type Props = {
+  className: string,
+  children: *,
+  raised: boolean,
+  type: 'button' | 'submit'
+}
 
-  getClassName(base) {
+export default class Button extends React.Component<Props> {
+  static defaultProps = {
+    className: '',
+    raised: false,
+    type: 'button'
+  }
+
+  getClassName(base: string) {
+    let { raised, className } = this.props
+
     let mods = cx('ars-button', {
       'ars-button-raised': this.props.raised
     })
 
     return cx(base, mods)
-  },
+  }
 
   render() {
-    let { className, children, ...attrs } = this.props
-
-    // Don't let raised fall through
-    delete attrs.raised
+    let { className, children, raised: _raised, ...attrs } = this.props
 
     return (
       <button className={this.getClassName(className)} {...attrs}>
@@ -36,6 +41,4 @@ let Button = createClass({
       </button>
     )
   }
-})
-
-export default Button
+}

--- a/src/style/components/figure.scss
+++ b/src/style/components/figure.scss
@@ -4,6 +4,7 @@
   border: 0;
   box-shadow: 0 1px 2px rgba(#000, 0.35);
   cursor: pointer;
+  color: $ars-accent;
   margin: 0;
   padding: 100% 0 0;
   position: relative;
@@ -12,10 +13,11 @@
 
   &:before {
     border: 0 solid transparent;
-    content: "";
+    content: '';
     height: 100%;
     left: 0;
     position: absolute;
+    pointer-events: none;
     top: 0;
     transition: 0.28s all;
     width: 100%;
@@ -65,9 +67,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   width: 100%;
-  z-index: 1;
 }
-
 
 // Transitions
 // -------------------------------------------------- //

--- a/src/style/components/selection.scss
+++ b/src/style/components/selection.scss
@@ -73,7 +73,6 @@
   display: block;
   line-height: 24px;
   margin: 0;
-  overflow: hidden;
   padding: 16px;
   text-align: center;
   text-overflow: ellipsis;

--- a/src/style/generators/extends.scss
+++ b/src/style/generators/extends.scss
@@ -5,9 +5,10 @@
     border: 3px solid transparent;
     border-radius: 8px;
     bottom: 0;
-    content: "";
+    content: '';
     left: 0;
     position: absolute;
+    pointer-events: none;
     right: 0;
     top: 0;
     transition: 0.28s all;


### PR DESCRIPTION
1. Replaces `createClass` with `React.Component`
2. Replaces prop types with Flow
3. Fixes touch regions for ink
4. Adds correct color ink for gallery images

![screenshot 2018-07-30 at 10 59 04 am](https://user-images.githubusercontent.com/590904/43414522-d63b26ee-93e7-11e8-9bdc-232c965b269a.png)
![screenshot 2018-07-30 at 10 58 59 am](https://user-images.githubusercontent.com/590904/43414523-d65a2d78-93e7-11e8-910c-7ad18cd5fc64.png)


---

This commit updates the Button component, replacing createClass with classical inheritance and prop types with Flow. Additionally, it makes a few fixes for ink and focus states where z-indexing and overflowing on focus states were causing a few issues.

