### PR TITLE
Use the same name on checkboxes to allow keyboard entry

### DIFF
--- a/src/components/table-view/checker.js
+++ b/src/components/table-view/checker.js
@@ -20,6 +20,7 @@ export default function Checker({
 
       <input
         type={multiselect ? 'checkbox' : 'radio'}
+        name="_ars_gallery_checker"
         onChange={onChange.bind(null, id)}
         checked={checked}
       />


### PR DESCRIPTION
Doing a bit of a11y testing, I noticed that the keyboard didn't move the radio to select an item. This PR fixes that :)

![record](https://user-images.githubusercontent.com/590904/45235870-0fcd9980-b28f-11e8-97e2-82492d3eb27d.gif)
