### PR TITLE
Fix single select "Clear" of current selection

### DIFF
--- a/src/components/__tests__/selection-test.js
+++ b/src/components/__tests__/selection-test.js
@@ -1,34 +1,30 @@
 import React from 'react'
 import Selection from '../selection'
-import Options from '../../contexts/options'
+import SelectionFigure from '../selection-figure'
 import { mount } from 'enzyme'
 
 jest.useFakeTimers()
 
 describe('Selection', () => {
-  test('renders a photo', () => {
-    let component = mount(
-      <Options.Provider value={{ url: 'data' }}>
-        <Selection url="data" slug="1.json" />
-      </Options.Provider>
-    )
+  test('renders a photo given a valid record slug', () => {
+    let component = mount(<Selection slug="data/1.json" />)
 
     jest.runAllTimers()
     component.update()
 
-    expect(component.find('img').exists()).toBe(true)
+    expect(component.find(SelectionFigure).exists()).toBe(true)
   })
 
-  test('does not render a photo', () => {
-    let component = mount(
-      <Options.Provider value={{ url: 'data' }}>
-        <Selection />
-      </Options.Provider>
-    )
+  test('does not render a photo when props.slug is falsey', () => {
+    let component = mount(<Selection slug="data/1.json" />)
 
     jest.runAllTimers()
     component.update()
 
-    expect(component.find('img').exists()).toBe(false)
+    expect(component.find(SelectionFigure).exists()).toBe(true)
+
+    component.setProps({ slug: null })
+
+    expect(component.find(SelectionFigure).exists()).toBe(false)
   })
 })

--- a/src/components/selection.tsx
+++ b/src/components/selection.tsx
@@ -18,7 +18,8 @@ interface Props {
 
 export default class Selection extends React.Component<Props, {}> {
   getPhoto(data: Record | null) {
-    return data != null ? <SelectionFigure item={data} /> : null
+    let showPhoto = data != null && this.props.slug
+    return showPhoto ? <SelectionFigure item={data} /> : null
   }
 
   renderContent({ data, fetching }: RecordResult) {


### PR DESCRIPTION
### Problem

In the 3.0.0 RC, single select pickers are not removing the photo when "clear" is clicked. 

### Fix

When the `<Selection>` slug used to find a record is falsey, don't render `<SelectionFigure />` (the photo component).