### PR TITLE
Do not allow duplicate entries in search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 3.3.0
+
+- Safely handle duplicate record entries returned from API responses
+- Add `logger` option to customize errors and warnings emitted from ArsArsenal
+
 ## 3.2.4
 
 - Fix an overflow bug in Chrome 72 where gallery items extended past container

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Ars Arsenal ships with a stylesheet. The easiest way to include it is by importi
 ```scss
 /* Sass stylesheet: */
 @import './node_modules/ars-arsenal/style/ars-arsenal.scss' /* or CSS: */
-@import './node_modules/ars-arsenal/style.css';
+  @import './node_modules/ars-arsenal/style.css';
 ```
 
 ### Icons
@@ -105,6 +105,23 @@ ArsArsenal.render(app, {
   request: function(url, callback) {
     // Behavior to configure networking. Return an XMLHTTPRequest
     return xhr(url, callback)
+  },
+
+  logger: function(level, message) {
+    // Override this method to handle usage warnings and issues
+    // ArsArsenal considers errors with API interaction. Useful
+    // for monitoring.
+    switch (level) {
+      case 'warning':
+        console.warn(message)
+        break
+      case 'error':
+        console.error(message)
+        break
+      default:
+        console.log(message)
+        break
+    }
   }
 })
 ```
@@ -118,7 +135,9 @@ import { Ars } from 'ars-arsenal'
 
 let app = document.getElementById('app')
 
-let options = { /* same options as above */ }
+let options = {
+  /* same options as above */
+}
 
 ReactDOM.render(<Ars options={options} />, app)
 ```
@@ -158,7 +177,7 @@ To transpose data, map over it in `onFetch` like so:
 ```javascript
 let options = {
   onFetch: function(response) {
-    return response.data.map(function (record) {
+    return response.data.map(function(record) {
       return {
         id: record.id,
         attribution: record.credit,

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Ars Arsenal ships with a stylesheet. The easiest way to include it is by importi
 
 ```scss
 /* Sass stylesheet: */
-@import './node_modules/ars-arsenal/style/ars-arsenal.scss' /* or CSS: */
-  @import './node_modules/ars-arsenal/style.css';
+@import './node_modules/ars-arsenal/style/ars-arsenal.scss'; /* or CSS: */
+@import './node_modules/ars-arsenal/style.css';
 ```
 
 ### Icons

--- a/src/components/__tests__/ars-test.js
+++ b/src/components/__tests__/ars-test.js
@@ -84,4 +84,24 @@ describe('Ars', () => {
       expect(component.find('Picker').exists()).toBe(true)
     })
   })
+
+  test('warns about duplicate API responses', () => {
+    let logger = jest.fn()
+
+    let request = (_url, success, _error) => {
+      success([{ id: 1 }, { id: 1 }])
+      return { abort() {} }
+    }
+
+    let component = mount(
+      <Ars url="/test.json" request={request} logger={logger} />
+    )
+
+    component.setState({ dialogOpen: true })
+
+    expect(logger).toHaveBeenCalledWith(
+      'error',
+      expect.stringContaining('Duplicate records were returned from /test.json')
+    )
+  })
 })

--- a/src/containers/load-collection.tsx
+++ b/src/containers/load-collection.tsx
@@ -5,7 +5,7 @@
 
 import * as React from 'react'
 import OptionsContext from '../contexts/options'
-import { ID, Record } from '../record'
+import { Record } from '../record'
 import {
   DEFAULT_OPTIONS,
   SortableColumn,
@@ -13,6 +13,7 @@ import {
 } from '../options'
 import { stringify } from 'query-string'
 import ScrollMonitor from '../components/scroll-monitor'
+import { dedupe } from '../utils/collection'
 
 export interface CollectionResult {
   data: Record[]
@@ -163,7 +164,7 @@ class CollectionFetcher extends React.Component<Props, State> {
       data.push(...requests[i].data)
     }
 
-    return data
+    return dedupe(data, 'id')
   }
 
   onSuccess(request: Request, body: Object) {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,15 @@
+export enum LogLevel {
+  Warning = 'warning',
+  Error = 'error'
+}
+
+export function logger(level: LogLevel, message: String) {
+  switch (level) {
+    case LogLevel.Warning:
+      console.warn(message)
+    case LogLevel.Error:
+      console.error(message)
+    default:
+      console.log(message)
+  }
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -7,9 +7,12 @@ export function logger(level: LogLevel, message: String) {
   switch (level) {
     case LogLevel.Warning:
       console.warn(message)
+      break
     case LogLevel.Error:
       console.error(message)
+      break
     default:
       console.log(message)
+      break
   }
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -2,6 +2,7 @@
  * These are all options available to Ars Arsenal
  */
 
+import { logger } from './logger'
 import { request } from './request'
 import { ID, Record } from './record'
 
@@ -50,6 +51,9 @@ export interface ArsOptions {
   picked?: ID | ID[]
   // What utility should Ars use for network requests?
   request: typeof request
+  // Method to report issues with Ars Arsenal. Use this method to
+  // provide custom error reporting.
+  logger: (level: String, message: String) => void
 }
 
 export interface ArsOptionsWithDeprecations extends ArsOptions {
@@ -70,5 +74,6 @@ export const DEFAULT_OPTIONS: ArsOptions = {
   resource: 'Photo',
   mode: 'gallery',
   columns: ['id', 'name', 'caption', 'attribution', 'tags', 'preview'],
-  request: request
+  request: request,
+  logger: logger
 }

--- a/src/utils/__tests__/collection-test.js
+++ b/src/utils/__tests__/collection-test.js
@@ -1,0 +1,17 @@
+import { dedupe } from '../collection'
+
+describe('dedupe', () => {
+  test('eliminates duplicates given a key', () => {
+    let result = dedupe([{ id: 1 }, { id: 2 }, { id: 1 }], 'id')
+
+    expect(result).toHaveLength(2)
+    expect(result.map(r => r.id)).toEqual([1, 2])
+  })
+
+  test('handles cases when all items are unique', () => {
+    let result = dedupe([{ id: 1 }, { id: 2 }], 'id')
+
+    expect(result).toHaveLength(2)
+    expect(result.map(r => r.id)).toEqual([1, 2])
+  })
+})

--- a/src/utils/collection.ts
+++ b/src/utils/collection.ts
@@ -1,0 +1,25 @@
+/**
+ * Removes duplicate records from a list, given a field to compare
+ * against. This is used to control for duplicate entries returned
+ * from API endpoints.
+ *
+ * Ultimately, we can't control this. However it is important to
+ * deduplicate search results for React indexing and user experience.
+ */
+export function dedupe<Item>(list: Item[], field: keyof Item): Item[] {
+  let bank = new Set()
+  let next = []
+
+  for (let i = 0, len = list.length; i < len; i++) {
+    let item = list[i]
+    let index = item[field]
+
+    if (bank.has(index) === false) {
+      next.push(item)
+    }
+
+    bank.add(index)
+  }
+
+  return next
+}


### PR DESCRIPTION
This commit fixes a bug where React would raise a key error if
duplicate entries were returned from an API. This is also important to
avoid user confusion when browsing a list of data.