### PR TITLE
Search pagination fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 3.4.1
+
+- Remove exit animation from gallery, which was resulting in an
+  undesired visual effect where gallery items flickered into new
+  results
+
 ## 3.3.0
 
 - Safely handle duplicate record entries returned from API responses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Remove exit animation from gallery, which was resulting in an
   undesired visual effect where gallery items flickered into new
   results
+- Fix case where searching broke pagination.
+- Scroll resets upon search
 
 ## 3.3.0
 

--- a/src/components/gallery.tsx
+++ b/src/components/gallery.tsx
@@ -49,6 +49,7 @@ export default class Gallery extends React.PureComponent<Props, State> {
       <CSSTransition
         key={index}
         appear={true}
+        exit={false}
         classNames="ars-gallery"
         timeout={delay + 400}
         onEntered={this.trackMount.bind(this, index)}

--- a/src/components/scroll-monitor.tsx
+++ b/src/components/scroll-monitor.tsx
@@ -3,6 +3,7 @@ import { findDOMNode } from 'react-dom'
 
 interface Props {
   page: number
+  refresh: string
   onPage: (number: number) => void
 }
 
@@ -43,11 +44,22 @@ class ScrollMonitor extends React.Component<Props, null> {
       this.lastChild = null
     }
 
+    if (this.props.refresh != lastProps.refresh) {
+      this.resetScroll()
+      this.check()
+    }
+
     this.subscribe()
   }
 
   componentWillUnmount() {
     this.teardown()
+  }
+
+  resetScroll() {
+    if (this.container) {
+      this.container.scrollTop = 0
+    }
   }
 
   check = () => {

--- a/src/containers/load-collection.tsx
+++ b/src/containers/load-collection.tsx
@@ -224,8 +224,16 @@ class CollectionFetcher extends React.Component<Props, State> {
   }
 
   render() {
+    // Refresh scrolling when these fields change. This causes the monitor to
+    // start from a clean slate whenever new results come in.
+    let token = [this.state.search, this.state.sort].join(':')
+
     return (
-      <ScrollMonitor page={this.state.page} onPage={this.onPage}>
+      <ScrollMonitor
+        refresh={token}
+        page={this.state.page}
+        onPage={this.onPage}
+      >
         {this.props.render(this.state)}
       </ScrollMonitor>
     )

--- a/src/containers/load-collection.tsx
+++ b/src/containers/load-collection.tsx
@@ -62,7 +62,7 @@ class CollectionFetcher extends React.Component<Props, State> {
     ...DEFAULT_OPTIONS,
     sort: 'id',
     search: '',
-    render: result => null
+    render: () => null
   }
 
   static getDerivedStateFromProps(nextProps: Props, lastState: State) {


### PR DESCRIPTION
This PR includes a series of fixes. The primary fix relates to a case where searching didn't invalidate some caching inside of the scroll monitor, however I fixed a few more things along the way:

*Remove buggy exit animation from gallery tiles*

The CSS transition for gallery items didn't account for exit
animations. This resulted in an annoying flickering as new results
came in.

The simplest solution is just to disable exit animations.

*Refresh scroll monitor when search or sort changes*

Before this commit, searching only checked scroll position when the
container changed. This was an optimization I added to avoid
constantly checking scroll, possibly triggering multiple pages of
pagination at once.

To fix this, I added a key to the scroll monitor so that it totally
refreshes whenever the sorting order or search changes.

_This also resets scroll position on search._