### PR TITLE
Add failed states

### DIFF
--- a/example/example.tsx
+++ b/example/example.tsx
@@ -46,7 +46,7 @@ DOM.render(
     <Example title="Basic Use: Table" options={{ ...options, mode: 'table' }} />
     <Example
       title="Basic Use: Pre-selected"
-      options={{ ...options, picked: [1] }}
+      options={{ ...options, picked: [-1] }}
     />
     <Example
       title="Multiselect: Basic"
@@ -54,7 +54,7 @@ DOM.render(
     />
     <Example
       title="Multiselect: Pre-selected"
-      options={{ ...options, multiselect: true, picked: [2, 3] }}
+      options={{ ...options, multiselect: true, picked: [2, 3, -1] }}
     />
     <Example
       title="Multiselect: Table"

--- a/example/example.tsx
+++ b/example/example.tsx
@@ -46,7 +46,7 @@ DOM.render(
     <Example title="Basic Use: Table" options={{ ...options, mode: 'table' }} />
     <Example
       title="Basic Use: Pre-selected"
-      options={{ ...options, picked: [-1] }}
+      options={{ ...options, picked: [1] }}
     />
     <Example
       title="Multiselect: Basic"

--- a/src/components/multiselection-item.tsx
+++ b/src/components/multiselection-item.tsx
@@ -5,32 +5,28 @@
 import * as React from 'react'
 import cx from 'classnames'
 import Image from './ui/image'
-import LoadRecord from '../containers/load-record'
+import SelectionNotFound from './ui/selection-not-found'
+import LoadRecord, { RecordResult } from '../containers/load-record'
 import { RefreshIcon } from '../icons'
 import { ID, Record } from '../record'
 
 interface Props {
   id: ID | null
+  resource: string
 }
 
 export default class MultiSelectionItem extends React.Component<Props> {
   getPhoto(photo: Record | null) {
-    if (photo == null) {
-      return null
-    }
-
-    return (
+    return photo ? (
       <Image className="ars-selection-photo" alt={photo.name} src={photo.url} />
-    )
+    ) : null
   }
 
-  renderContent({
-    data,
-    fetching
-  }: {
-    data: Record | null
-    fetching: boolean
-  }) {
+  renderContent({ data, fetching, initialized }: RecordResult) {
+    if (initialized && !fetching && data == null) {
+      return <SelectionNotFound resource={this.props.resource} />
+    }
+
     let className = cx('ars-multiselection-cell', {
       'ars-is-loading': fetching,
       'ars-has-photo': data

--- a/src/components/multiselection.tsx
+++ b/src/components/multiselection.tsx
@@ -23,7 +23,7 @@ export default class MultiSelection extends React.Component<Props> {
   }
 
   getItems() {
-    let { ids } = this.props
+    let { ids, resource } = this.props
 
     if (!ids.length) {
       return null
@@ -32,7 +32,7 @@ export default class MultiSelection extends React.Component<Props> {
     return (
       <div className="ars-multiselection-grid">
         {ids.map(id => (
-          <MultiSelectionItem key={id} id={id} />
+          <MultiSelectionItem key={id} id={id} resource={resource} />
         ))}
       </div>
     )

--- a/src/components/selection.tsx
+++ b/src/components/selection.tsx
@@ -6,6 +6,7 @@ import * as React from 'react'
 import cx from 'classnames'
 import Button from './ui/button'
 import SelectionFigure from './selection-figure'
+import SelectionNotFound from './ui/selection-not-found'
 import selectionText from './selection-text'
 import { EditIcon, ClearIcon } from '../icons'
 import LoadRecord, { RecordResult } from '../containers/load-record'
@@ -19,12 +20,17 @@ interface Props {
 }
 
 export default class Selection extends React.Component<Props, {}> {
-  getPhoto(data: Record | null) {
+  getPhoto(data: Record | null, fetching: Boolean, initialized: Boolean) {
+    if (initialized && !fetching && data == null) {
+      return <SelectionNotFound resource={this.props.resource} />
+    }
+
     let showPhoto = data != null && this.props.id != null
+
     return showPhoto ? <SelectionFigure item={data} /> : null
   }
 
-  renderContent({ data, fetching }: RecordResult) {
+  renderContent({ data, fetching, initialized }: RecordResult) {
     let { resource, onEdit, onClear } = this.props
 
     let hasPicked = this.props.id != null
@@ -38,7 +44,7 @@ export default class Selection extends React.Component<Props, {}> {
 
     return (
       <div className={className}>
-        {this.getPhoto(data)}
+        {this.getPhoto(data, fetching, initialized)}
 
         <footer className="ars-selection-actions">
           <Button onClick={onEdit} title={title}>

--- a/src/components/ui/selection-not-found.tsx
+++ b/src/components/ui/selection-not-found.tsx
@@ -1,0 +1,24 @@
+/**
+ * Image
+ * A wrapper around image elements to handle loading states and
+ * transitions
+ */
+
+import * as React from 'react'
+
+interface Props {
+  resource: String
+}
+
+const SelectionNotFound: React.SFC<Props> = ({ resource }) => (
+  <div className="ars-selection-failed">
+    <section className="ars-selection-failed-banner">
+      <h3 className="ars-selection-failed-title">
+        Unable to find {resource.toLowerCase()}
+      </h3>
+      <p className="ars-selection-failed-body">It may have been deleted.</p>
+    </section>
+  </div>
+)
+
+export default SelectionNotFound

--- a/src/components/ui/selection-not-found.tsx
+++ b/src/components/ui/selection-not-found.tsx
@@ -1,9 +1,3 @@
-/**
- * Image
- * A wrapper around image elements to handle loading states and
- * transitions
- */
-
 import * as React from 'react'
 
 interface Props {

--- a/src/containers/load-record.tsx
+++ b/src/containers/load-record.tsx
@@ -12,6 +12,7 @@ export interface RecordResult {
   data: Record | null
   error: string | null
   fetching: boolean
+  initialized: boolean
 }
 
 interface Props extends ArsOptionsWithDeprecations {
@@ -24,6 +25,7 @@ interface State {
   error: string | null
   fetching: boolean
   targetURL: string
+  initialized: false
 }
 
 function isValidId(id: ID): boolean {
@@ -59,7 +61,8 @@ class RecordFetcher extends React.Component<Props, State> {
     data: null,
     error: null,
     fetching: false,
-    targetURL: ''
+    targetURL: '',
+    initialized: false
   }
 
   componentDidMount() {
@@ -94,7 +97,8 @@ class RecordFetcher extends React.Component<Props, State> {
     this.setState({
       data: this.props.onFetch(data) as Record,
       error: null,
-      fetching: false
+      fetching: false,
+      initialized: true
     })
   }
 
@@ -102,7 +106,8 @@ class RecordFetcher extends React.Component<Props, State> {
     this.setState({
       data: null,
       error: this.props.onError(error),
-      fetching: false
+      fetching: false,
+      initialized: true
     })
   }
 

--- a/src/style/components/multiselection.scss
+++ b/src/style/components/multiselection.scss
@@ -6,6 +6,12 @@
   max-width: 400px;
 }
 
+.ars-multiselection .ars-selection-failed {
+  padding: 4px;
+  height: 100px;
+  width: 50%;
+}
+
 .ars-multiselection-grid {
   display: flex;
   flex-wrap: wrap;

--- a/src/style/components/selection.scss
+++ b/src/style/components/selection.scss
@@ -35,6 +35,29 @@
   max-height: 225px;
 }
 
+.ars-selection-failed-banner {
+  align-items: center;
+  box-shadow: 0 0 0 1px $ars-danger;
+  border-radius: 1px;
+  background: rgba($ars-danger, 0.3);
+  color: darken($ars-danger, 40%);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 100%;
+}
+
+.ars-selection-failed-title {
+  font-size: 14px;
+  margin: 0 0 8px;
+}
+
+.ars-selection-failed-body {
+  font-size: 10px;
+  margin: 0;
+}
+
 .ars-selection-desc {
   transition: 0.55s opacity;
 }


### PR DESCRIPTION
This commit adds failed states to ars arsenal. I noticed in a few
integrations that if a photo is deleted, nothing shows up to tell the
user that ars can't load in the data.

![image](https://user-images.githubusercontent.com/590904/52020470-3bebf000-24a6-11e9-8745-0ee4b425d60a.png)
