### PR TITLE
Improve focus/active state of gallery

### DIFF
--- a/src/style/ars-arsenal.scss
+++ b/src/style/ars-arsenal.scss
@@ -3,6 +3,7 @@ $ars-primary: #009688 !default;
 $ars-accent: #cddc39 !default;
 $ars-danger: #f44336 !default;
 $ars-focus: #0088ff !default;
+$ars-selected: gold !default;
 $ars-text-light: rgba(#fff, 0.875) !default;
 $ars-text-dark: rgba(#000, 0.875) !default;
 $ars-muted-light: rgba(#fff, 0.4) !default;

--- a/src/style/ars-arsenal.scss
+++ b/src/style/ars-arsenal.scss
@@ -2,6 +2,7 @@ $ars-font-family: Roboto, sans-serif;
 $ars-primary: rgb(0, 150, 136) !default;
 $ars-accent: #cddc39 !default;
 $ars-danger: #f44336 !default;
+$ars-focus: #0088ff !default;
 $ars-text-light: rgba(#fff, 0.875) !default;
 $ars-text-dark: rgba(#000, 0.875) !default;
 $ars-muted-light: rgba(#fff, 0.4) !default;

--- a/src/style/ars-arsenal.scss
+++ b/src/style/ars-arsenal.scss
@@ -1,5 +1,5 @@
 $ars-font-family: Roboto, sans-serif;
-$ars-primary: rgb(0, 150, 136) !default;
+$ars-primary: #009688 !default;
 $ars-accent: #cddc39 !default;
 $ars-danger: #f44336 !default;
 $ars-focus: #0088ff !default;

--- a/src/style/components/figure.scss
+++ b/src/style/components/figure.scss
@@ -43,13 +43,9 @@
     background: rgba($ars-selected, 0.12);
     box-shadow: 0 1px 2px 0px rgba(0, 0, 0, 0.45);
     top: -3px;
-    bottom: - 3px;
+    bottom: -3px;
     left: -3px;
     right: -3px;
-  }
-
-  canvas {
-    z-index: 4;
   }
 }
 

--- a/src/style/components/figure.scss
+++ b/src/style/components/figure.scss
@@ -39,8 +39,8 @@
   }
 
   &.ars-fig-picked:before {
-    border: 4px solid gold;
-    background: rgba(gold, 0.12);
+    border: 4px solid $ars-selected;
+    background: rgba($ars-selected, 0.12);
     box-shadow: 0 1px 2px 0px rgba(0, 0, 0, 0.45);
     top: -3px;
     bottom: - 3px;

--- a/src/style/components/figure.scss
+++ b/src/style/components/figure.scss
@@ -13,32 +13,42 @@
 
   &:before {
     border: 0 solid transparent;
+    bottom: -4px;
+    border-radius: 2px;
     content: '';
-    height: 100%;
-    left: 0;
-    position: absolute;
+    left: -4px;
     pointer-events: none;
-    top: 0;
+    position: absolute;
+    right: -4px;
+    top: -4px;
     transition: 0.28s all;
-    width: 100%;
     z-index: 3;
   }
 
   &:focus {
-    box-shadow: 0 1px 2px rgba(#000, 0.25);
     outline: none;
 
     &:before {
-      border: 4px solid $ars-accent;
+      border: 2px solid $ars-focus;
+      background: rgba($ars-focus, 0.12);
     }
+  }
+
+  &:active:before {
+    border-width: 4px;
   }
 
   &.ars-fig-picked:before {
     border: 4px solid gold;
+    background: rgba(gold, 0.12);
+    box-shadow: 0 1px 2px 0px rgba(0, 0, 0, 0.45);
+    top: -3px;
+    bottom: - 3px;
+    left: -3px;
+    right: -3px;
   }
 
-  .ink {
-    color: $ars-accent;
+  canvas {
     z-index: 4;
   }
 }


### PR DESCRIPTION
I noticed that it's really hard right now to tell if a photo has been
deselected. This is because the active state is gold and the focus
state is lime green.

This commit fixes this by changing both the shape and color of focus
states in the gallery.

**Before**

![image](https://user-images.githubusercontent.com/590904/52068172-ffb1a180-2530-11e9-8b6d-d98ab9e09546.png)

**After**
![image](https://user-images.githubusercontent.com/590904/52068141-ee689500-2530-11e9-8add-05f535a8fae0.png)
