### PR TITLE
Disable browser autocomplete

### DIFF
--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -38,7 +38,7 @@ export default class Search extends React.Component<Props> {
 
     let autoCompleteOpts = {}
     if (!autoComplete) {
-      autoCompleteOpts['autoComplete'] = 'none'
+      autoCompleteOpts['autoComplete'] = 'off'
     }
 
     return (

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -48,6 +48,7 @@ export default class Search extends React.Component<Props> {
         </label>
         <input
           {...autoCompleteOpts}
+          id={inputId}
           list={autoComplete ? listId : null}
           type="search"
           className="ars-search-input"

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -36,13 +36,18 @@ export default class Search extends React.Component<Props> {
     let inputId = `ars_search_${this.id}`
     let listId = `ars_search_list_${this.id}`
 
+    let autoCompleteOpts = {}
+    if (!autoComplete) {
+      autoCompleteOpts['autoComplete'] = 'none'
+    }
+
     return (
       <form className="ars-search" onSubmit={this.onSubmit.bind(this)}>
         <label className="ars-search-label" htmlFor={inputId}>
           <SearchIcon />
         </label>
         <input
-          id={inputId}
+          {...autoCompleteOpts}
           list={autoComplete ? listId : null}
           type="search"
           className="ars-search-input"


### PR DESCRIPTION
If the `autoComplete` option is false, the browser's autocomplete should also be disabled.